### PR TITLE
billiards-love-235 [Back-end] 회원 권한에 따른 다른 대회 목록 리턴

### DIFF
--- a/back-end/build.gradle
+++ b/back-end/build.gradle
@@ -63,6 +63,13 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven {
+        url = uri("https://raw.githack.com/antop-dev/log4jdbc-log4j2-jdbc4.1/master/maven/")
+        metadataSources {
+            mavenPom()
+            artifact()
+        }
+    }
 }
 
 dependencies {
@@ -83,6 +90,7 @@ dependencies {
     implementation "io.sentry:sentry-spring-boot-starter:$sentryVersion"
     // https://github.com/candrews/log4jdbc-spring-boot-starter/
     implementation "com.integralblue:log4jdbc-spring-boot-starter:$log4jdbcSpring"
+    implementation "org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16-kr"
     // https://mariadb.com/kb/en/about-mariadb-connector-j/
     implementation "org.mariadb.jdbc:mariadb-java-client:$mariadbVersion"
     // https://commons.apache.org/proper/commons-io/

--- a/back-end/src/docs/asciidoc/index.adoc
+++ b/back-end/src/docs/asciidoc/index.adoc
@@ -79,6 +79,8 @@ include::{snippets}/error-bad-credentials/http-response.adoc[]
 
 대회 목록을 조회한다.
 
+일반 회원/관리자 권한에 따라 필터링된 목록이 조회된다.
+
 .request
 include::{snippets}/contest-list/request-headers.adoc[]
 

--- a/back-end/src/main/java/org/antop/billiardslove/api/ContestInfoApi.java
+++ b/back-end/src/main/java/org/antop/billiardslove/api/ContestInfoApi.java
@@ -50,7 +50,7 @@ public class ContestInfoApi {
      */
     @GetMapping("/api/v1/contests")
     public List<ContestDto> list() {
-        return contestService.getAllContests();
+        return contestService.getContests();
     }
 
     /**

--- a/back-end/src/main/java/org/antop/billiardslove/dao/ContestDao.java
+++ b/back-end/src/main/java/org/antop/billiardslove/dao/ContestDao.java
@@ -7,14 +7,12 @@ import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 
 import static org.antop.billiardslove.jpa.entity.QContest.contest;
+import static org.antop.billiardslove.model.ContestState.PREPARING;
+import static org.antop.billiardslove.model.ContestState.STOPPED;
 
 @Slf4j
 @Repository
@@ -49,19 +47,27 @@ public class ContestDao extends QuerydslRepositorySupport {
     }
 
     /**
-     * 정렬하여 조회한다.
+     * 회원을 위한 대회 목록을 조회한다.<br>
+     * 준비중, 종료
      *
      * @return 대회 목록
      */
-    public List<Contest> findAllOrdered() {
-        List<Contest> fetch = from(contest)
-                .orderBy(contest.state.asc(),
-                        // NULL을 정렬에서 아래로 보낸다.
-                        contest.startDate.coalesce(LocalDate.of(9999, 12, 31)).asc(),
-                        contest.startTime.coalesce(LocalTime.of(23, 59, 59, 999999)).asc(),
-                        contest.created.desc())
+    public List<Contest> findListForMember() {
+        return from(contest)
+                .where(contest.state.notIn(PREPARING, STOPPED))
+                .orderBy(contest.id.desc())
                 .fetch();
-        return new ArrayList<>(new LinkedHashSet<>(fetch));
+    }
+
+    /**
+     * 관리자를 위한 모든 대회 목록 조회
+     *
+     * @return 대회 목록
+     */
+    public List<Contest> findListForManager() {
+        return from(contest)
+                .orderBy(contest.id.desc())
+                .fetch();
     }
 
     @Transactional

--- a/back-end/src/main/java/org/antop/billiardslove/service/ContestService.java
+++ b/back-end/src/main/java/org/antop/billiardslove/service/ContestService.java
@@ -55,9 +55,12 @@ public class ContestService {
      *
      * @return 대회 목록
      */
-    public List<ContestDto> getAllContests() {
-        return contestDao.findAllOrdered()
-                .stream()
+    public List<ContestDto> getContests() {
+        List<Contest> contests = SecurityUtils.isManager()
+                ? contestDao.findListForManager()
+                : contestDao.findListForMember();
+
+        return contests.stream()
                 .map(contest -> contestMapper.toDto(contest, SecurityUtils.getMemberId()))
                 .collect(Collectors.toList());
     }

--- a/back-end/src/main/java/org/antop/billiardslove/util/SecurityUtils.java
+++ b/back-end/src/main/java/org/antop/billiardslove/util/SecurityUtils.java
@@ -5,6 +5,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import static org.antop.billiardslove.config.security.JwtAuthenticationToken.ROLE_MANAGER;
+
 /**
  * 스프링 시큐리티 유틸리티
  */
@@ -18,13 +20,22 @@ public class SecurityUtils {
      * @return 회원 아이디
      */
     public static long getMemberId() {
-        SecurityContext securityContext = SecurityContextHolder.getContext();
-        Authentication authentication = securityContext.getAuthentication();
-        if (authentication == null) {
-            throw new NotLoginException();
-        }
-        return (long) authentication.getPrincipal();
+        return (long) getAuthentication().getPrincipal();
+    }
 
+    /**
+     * 현재 로그인된 회원이 관리자인지 여부
+     */
+    public static boolean isManager() {
+        return getAuthentication().getAuthorities().stream()
+                .anyMatch(it -> it.getAuthority().equals(ROLE_MANAGER));
+    }
+
+    private static Authentication getAuthentication() {
+        SecurityContext securityContext = SecurityContextHolder.getContext();
+        Authentication auth = securityContext.getAuthentication();
+        if (auth == null) throw new NotLoginException();
+        return auth;
     }
 
 }

--- a/back-end/src/main/resources/api-docs/openapi3.json
+++ b/back-end/src/main/resources/api-docs/openapi3.json
@@ -62,7 +62,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "error-forbidden" : {
@@ -87,7 +87,7 @@
           "schema" : {
             "type" : "string"
           },
-          "example" : "2"
+          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzIiwiaWF0IjoxNjQxNjkzODAyLCJleHAiOjE2NDE2OTU2MDJ9.G1mHmD-uzva3FBWx5A5ch-riUKrTR6rT6l7Ht6s4Xc0"
         } ],
         "responses" : {
           "200" : {
@@ -99,7 +99,7 @@
                 },
                 "examples" : {
                   "contest-list" : {
-                    "value" : "[ {\r\n  \"id\" : 1121,\r\n  \"title\" : \"2020년 7월 동호회 리그전\",\r\n  \"description\" : \"총 상금 100만원!\",\r\n  \"startDate\" : \"2021-07-01\",\r\n  \"startTime\" : \"18:00:00\",\r\n  \"endDate\" : \"2020-07-31\",\r\n  \"endTime\" : \"22:00:00\",\r\n  \"maxJoiner\" : 128,\r\n  \"currentJoiner\" : 0,\r\n  \"stateCode\" : \"END\",\r\n  \"stateName\" : \"종료\",\r\n  \"progress\" : 0.0,\r\n  \"player\" : {\r\n    \"id\" : 335,\r\n    \"number\" : 16,\r\n    \"handicap\" : 18,\r\n    \"nickname\" : \"띠용\",\r\n    \"rank\" : 5,\r\n    \"score\" : 600,\r\n    \"variation\" : 0\r\n  }\r\n}, {\r\n  \"id\" : 1121,\r\n  \"title\" : \"2022년 1분기 대회\",\r\n  \"startDate\" : \"2022-01-01\",\r\n  \"startTime\" : \"18:00:00\",\r\n  \"endDate\" : \"2022-03-31\",\r\n  \"maxJoiner\" : 64,\r\n  \"currentJoiner\" : 0,\r\n  \"stateCode\" : \"PREPARING\",\r\n  \"stateName\" : \"준비중\",\r\n  \"progress\" : 0.0\r\n} ]"
+                    "value" : "[ {\r\n  \"id\" : 7,\r\n  \"title\" : \"접수중 대회 - 인원 꽉참\",\r\n  \"startDate\" : \"2021-01-01\",\r\n  \"maxJoiner\" : 2,\r\n  \"currentJoiner\" : 2,\r\n  \"stateCode\" : \"ACCEPTING\",\r\n  \"stateName\" : \"접수중\",\r\n  \"progress\" : 0.0\r\n}, {\r\n  \"id\" : 6,\r\n  \"title\" : \"종료된 대회\",\r\n  \"startDate\" : \"2020-01-01\",\r\n  \"currentJoiner\" : 0,\r\n  \"stateCode\" : \"END\",\r\n  \"stateName\" : \"종료\",\r\n  \"progress\" : 0.0\r\n}, {\r\n  \"id\" : 2,\r\n  \"title\" : \"2022 리그전\",\r\n  \"description\" : \"2021.05.01~\",\r\n  \"startDate\" : \"2021-01-01\",\r\n  \"startTime\" : \"00:00:00\",\r\n  \"endDate\" : \"2022-12-30\",\r\n  \"endTime\" : \"23:59:59\",\r\n  \"maxJoiner\" : 128,\r\n  \"currentJoiner\" : 4,\r\n  \"stateCode\" : \"ACCEPTING\",\r\n  \"stateName\" : \"접수중\",\r\n  \"progress\" : 0.0,\r\n  \"player\" : {\r\n    \"id\" : 9,\r\n    \"handicap\" : 28,\r\n    \"nickname\" : \"잼미니\",\r\n    \"score\" : 0,\r\n    \"variation\" : 0\r\n  }\r\n}, {\r\n  \"id\" : 1,\r\n  \"title\" : \"2021 리그전\",\r\n  \"description\" : \"2021.01.01~\",\r\n  \"startDate\" : \"2021-01-01\",\r\n  \"startTime\" : \"00:00:00\",\r\n  \"endDate\" : \"2021-12-30\",\r\n  \"endTime\" : \"23:59:59\",\r\n  \"maxJoiner\" : 32,\r\n  \"currentJoiner\" : 5,\r\n  \"stateCode\" : \"PROCEEDING\",\r\n  \"stateName\" : \"진행중\",\r\n  \"progress\" : 0.0,\r\n  \"player\" : {\r\n    \"id\" : 3,\r\n    \"number\" : 3,\r\n    \"handicap\" : 26,\r\n    \"nickname\" : \"잼미니\",\r\n    \"rank\" : 5,\r\n    \"score\" : 10,\r\n    \"variation\" : 0\r\n  }\r\n} ]"
                   }
                 }
               }
@@ -122,7 +122,7 @@
                 },
                 "examples" : {
                   "init" : {
-                    "value" : "{\r\n  \"secretKey\" : \"ndhzV7N5Oj8Lh4YNMRk0p2xGaJZ2Wgv7roBOpg2g1aA=\",\r\n  \"kakaoKey\" : \"+HwoS7ksIK49f97pcQEbFNQxwmuDCgovPBLlLr+AnnS9a2R5gFyx/PiUAkzTHuzKDQ==\",\r\n  \"adSenseKey\" : \"VInZ6MpZf8RRu3WDKFI02xseiXS4zNzQx53TpZpbR/sW9Lrec24iQMseh0425A==\"\r\n}"
+                    "value" : "{\r\n  \"secretKey\" : \"mYhdmQWRbaHCkYV6vsQqjJePKAWiOT4sd0AF84Q03rs=\",\r\n  \"kakaoKey\" : \"yZj9w3iwryQHJyyifvI0MYIxlu7q6OpKB5kvD9b+RW4tYVadSkByoaWb5EAKffeUUA==\",\r\n  \"adSenseKey\" : \"5IGhzXKEr+6fMZTzcOyQHTd66Hp330AG00tqX+tHqBPr+D6ZQ5D27RtEWrgUGQ==\"\r\n}"
                   }
                 }
               }
@@ -143,10 +143,10 @@
               },
               "examples" : {
                 "logged-in" : {
-                  "value" : "{\r\n  \"id\" : 9999,\r\n  \"connectedAt\" : 1.597679104E9,\r\n  \"profile\" : {\r\n    \"nickname\" : \"9rQ/Kyne0DHYNC9UnK64OKwNP/FzdlCBF1i79xmtD5Vb\",\r\n    \"imageUrl\" : \"https://cataas.com/cat?width=200&height=200\",\r\n    \"thumbnailUrl\" : \"https://cataas.com/cat?width=160&height=100\",\r\n    \"needsAgreement\" : true\r\n  }\r\n}"
+                  "value" : "{\r\n  \"id\" : 9999,\r\n  \"connectedAt\" : 1.597679104E9,\r\n  \"profile\" : {\r\n    \"nickname\" : \"gIKZ7uKOtbrYKobRDGO0WLwO9BSqTxe5wjz1armpOYlu\",\r\n    \"imageUrl\" : \"https://cataas.com/cat?width=200&height=200\",\r\n    \"thumbnailUrl\" : \"https://cataas.com/cat?width=160&height=100\",\r\n    \"needsAgreement\" : true\r\n  }\r\n}"
                 },
                 "logged-in-registered" : {
-                  "value" : "{\r\n  \"id\" : 1,\r\n  \"connectedAt\" : 1.597671904E9,\r\n  \"profile\" : {\r\n    \"nickname\" : \"jV/JlyeDAmb9b4+OFtz0X2QSTAwMewbgh89rx5rKJQW+\",\r\n    \"imageUrl\" : \"https://foo\",\r\n    \"thumbnailUrl\" : \"https://bar\",\r\n    \"needsAgreement\" : true\r\n  }\r\n}"
+                  "value" : "{\r\n  \"id\" : 1,\r\n  \"connectedAt\" : 1.597671904E9,\r\n  \"profile\" : {\r\n    \"nickname\" : \"ZPjxvOQn1FhpgHQqkHmFHc+P/ptPSfnWImXk0zf/M2N/\",\r\n    \"imageUrl\" : \"https://foo\",\r\n    \"thumbnailUrl\" : \"https://bar\",\r\n    \"needsAgreement\" : true\r\n  }\r\n}"
                 }
               }
             }
@@ -162,10 +162,10 @@
                 },
                 "examples" : {
                   "logged-in" : {
-                    "value" : "{\r\n  \"token\" : \"created jwt token value!\",\r\n  \"member\" : {\r\n    \"id\" : 12,\r\n    \"nickname\" : \"GvavN+NWUCGn58qiI2f9oAEgZwQci5q5ZvbMI8C4rifK\",\r\n    \"thumbnail\" : \"https://cataas.com/cat?width=160&height=100\",\r\n    \"manager\" : false\r\n  },\r\n  \"registered\" : false\r\n}"
+                    "value" : "{\r\n  \"token\" : \"created jwt token value!\",\r\n  \"member\" : {\r\n    \"id\" : 12,\r\n    \"nickname\" : \"aCYl/ftXS2uFMgyWF8VE9qAIzHaT4vnYxY664zr1kxs8\",\r\n    \"thumbnail\" : \"https://cataas.com/cat?width=160&height=100\",\r\n    \"manager\" : false\r\n  },\r\n  \"registered\" : false\r\n}"
                   },
                   "logged-in-registered" : {
-                    "value" : "{\r\n  \"token\" : \"created jwt token value!\",\r\n  \"member\" : {\r\n    \"id\" : 12,\r\n    \"nickname\" : \"mjTF8Yy5dY4Qj6wcYiLIc8ROAUmbEr/tyVkLthGqM35sEw==\",\r\n    \"handicap\" : 22,\r\n    \"thumbnail\" : \"https://bar\",\r\n    \"manager\" : true\r\n  },\r\n  \"registered\" : true\r\n}"
+                    "value" : "{\r\n  \"token\" : \"created jwt token value!\",\r\n  \"member\" : {\r\n    \"id\" : 12,\r\n    \"nickname\" : \"gO94wzjkuoMZYX7iR9AmC4IDG46WwgLfqMhcFltcT73+Sw==\",\r\n    \"handicap\" : 22,\r\n    \"thumbnail\" : \"https://bar\",\r\n    \"manager\" : true\r\n  },\r\n  \"registered\" : true\r\n}"
                   }
                 }
               }
@@ -196,10 +196,10 @@
               },
               "examples" : {
                 "error-bad-credentials" : {
-                  "value" : "{\r\n  \"nickname\" : \"s5kEf6MlE60qUuu9YautU3/lBNus24/J3fhUp/556z8C\",\r\n  \"handicap\" : 30\r\n}"
+                  "value" : "{\r\n  \"nickname\" : \"pAQi7wSMDiSgIC1kEf9qSCigqYUrAow+ezV9eHfB7UOX\",\r\n  \"handicap\" : 30\r\n}"
                 },
                 "member-modify" : {
-                  "value" : "{\r\n  \"nickname\" : \"EoFE/HE6ODmopftzVz74CeKYcC2UwqfQbOoRv8M0I9RVoZ3cmb97yFwmJVA=\",\r\n  \"handicap\" : 30\r\n}"
+                  "value" : "{\r\n  \"nickname\" : \"LGpLo32Zr0I2oYphEkTt1xB3r94picbGhvPgTG2cVWpVtRp771h3w5GgEIs=\",\r\n  \"handicap\" : 30\r\n}"
                 },
                 "member-modify-valid-handicap-not-null" : {
                   "value" : "{\r\n  \"nickname\" : \"NICKNAME\",\r\n  \"handicap\" : null\r\n}"
@@ -220,7 +220,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "error-bad-credentials" : {
@@ -239,7 +239,7 @@
                 },
                 "examples" : {
                   "member-modify" : {
-                    "value" : "{\r\n  \"id\" : 2,\r\n  \"nickname\" : \"ZTGjwh2wxZSUpIBaw49Em++HZpMlYK2ou86XXegwqd5yMp/OB9NmGOi8kYg=\",\r\n  \"handicap\" : 30,\r\n  \"thumbnail\" : \"https://img.foo.bar\",\r\n  \"manager\" : false\r\n}"
+                    "value" : "{\r\n  \"id\" : 2,\r\n  \"nickname\" : \"ZrW7zNtSUGvfEFGdRnS4PMo6wwD0lV85+Z6gpzbZPB61Qp0J58TTy5enALs=\",\r\n  \"handicap\" : 30,\r\n  \"thumbnail\" : \"https://img.foo.bar\",\r\n  \"manager\" : false\r\n}"
                   }
                 }
               }
@@ -250,7 +250,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "member-modify-valid-handicap-not-null" : {
@@ -289,7 +289,7 @@
           "schema" : {
             "type" : "string"
           },
-          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNDc3NjMwLCJleHAiOjE2NDE0Nzk0MzB9.RZz4bC8xAUWGz-LkBd05Vjz1J9jVe4wtGFmhwaAqoJs"
+          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNjkzODAyLCJleHAiOjE2NDE2OTU2MDJ9.gzr-RrW-2tklgL8jjy756H4qv1bTDiI1X5MuUIlQUcE"
         } ],
         "responses" : {
           "200" : {
@@ -315,7 +315,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "contest-get-not-found" : {
@@ -417,7 +417,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "error-already-contest-end" : {
@@ -566,7 +566,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "error-match-not-found" : {
@@ -581,7 +581,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "match-result-enter-bad-request" : {
@@ -617,7 +617,7 @@
           "schema" : {
             "type" : "string"
           },
-          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNDc3NjI4LCJleHAiOjE2NDE0Nzk0Mjh9.u85SK8Bc6DwKZO9J0LX3ez0dzCZ0ba5A-4gFOMCoh0k"
+          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNjkzODAwLCJleHAiOjE2NDE2OTU2MDB9.kdyd___6sEkts7wbwpHAvSLgpUNCXbI8Zqd9k5X73x8"
         } ],
         "responses" : {
           "200" : {
@@ -640,7 +640,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "contest-end-accept" : {
@@ -661,7 +661,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "contest-end-not-manager" : {
@@ -694,7 +694,7 @@
           "schema" : {
             "type" : "string"
           },
-          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI1IiwiaWF0IjoxNjQxNDc3NjMwLCJleHAiOjE2NDE0Nzk0MzB9.h3yAuhUgmxuyEw3OucbxbxGXlzOJsm1Z2l7I0zmVSvA"
+          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI1IiwiaWF0IjoxNjQxNjkzODAyLCJleHAiOjE2NDE2OTU2MDJ9.oS7PCBCMmQmB9zShKQc4D4SOALddhqxsYqqF7iBYB6E"
         } ],
         "requestBody" : {
           "content" : {
@@ -829,7 +829,7 @@
           "schema" : {
             "type" : "string"
           },
-          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNDc3NjMyLCJleHAiOjE2NDE0Nzk0MzJ9._JRbIPqPNap2eV4rJLL6Aqsm_t5RHM3Ispew6PQkkcA"
+          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNjkzODA0LCJleHAiOjE2NDE2OTU2MDR9.9KxicxmasofwfVFQeFmFM7Z-oMeJ6SUoB1IU5v_hbXE"
         } ],
         "responses" : {
           "200" : {
@@ -841,7 +841,7 @@
                 },
                 "examples" : {
                   "contest-open" : {
-                    "value" : "{\r\n  \"id\" : 3,\r\n  \"title\" : \"준비중인 대회 (1)\",\r\n  \"startDate\" : \"2022-01-06\",\r\n  \"endDate\" : \"2022-01-06\",\r\n  \"currentJoiner\" : 0,\r\n  \"stateCode\" : \"ACCEPTING\",\r\n  \"stateName\" : \"접수중\",\r\n  \"progress\" : 0.0\r\n}"
+                    "value" : "{\r\n  \"id\" : 3,\r\n  \"title\" : \"준비중인 대회 (1)\",\r\n  \"startDate\" : \"2022-01-09\",\r\n  \"endDate\" : \"2022-01-09\",\r\n  \"currentJoiner\" : 0,\r\n  \"stateCode\" : \"ACCEPTING\",\r\n  \"stateName\" : \"접수중\",\r\n  \"progress\" : 0.0\r\n}"
                   }
                 }
               }
@@ -852,7 +852,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "contest-open-end" : {
@@ -879,7 +879,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "contest-open-not-manager" : {
@@ -953,7 +953,7 @@
           "schema" : {
             "type" : "string"
           },
-          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNDc3NjMzLCJleHAiOjE2NDE0Nzk0MzN9.st-cA5KEtMBzWADEfspWRoHG0IkEXKFE_9ZVajRZi28"
+          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNjkzODA2LCJleHAiOjE2NDE2OTU2MDZ9.NKtVwLHniMNjnNllNLV50ZI8UxmMht2B06dffCxjGI8"
         } ],
         "responses" : {
           "200" : {
@@ -976,7 +976,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "contest-start-end" : {
@@ -997,7 +997,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "contest-start-not-manager" : {
@@ -1030,7 +1030,7 @@
           "schema" : {
             "type" : "string"
           },
-          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNDc3NjM1LCJleHAiOjE2NDE0Nzk0MzV9.ZsrFS0VxFntEx1ZFOpAANEHh-XnKQjNviHgFDGcQKFY"
+          "example" : "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNjkzODA4LCJleHAiOjE2NDE2OTU2MDh9.fU1M2ypvyrgAI2ri1dKP5yWI-dlkLhssHjjZLsNo2Dk"
         } ],
         "responses" : {
           "400" : {
@@ -1038,7 +1038,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "contest-state-end" : {
@@ -1056,7 +1056,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "contest-state-not-manager" : {
@@ -1078,7 +1078,7 @@
                 },
                 "examples" : {
                   "contest-stop" : {
-                    "value" : "{\r\n  \"id\" : 3,\r\n  \"title\" : \"준비중인 대회 (1)\",\r\n  \"startDate\" : \"2022-01-06\",\r\n  \"endDate\" : \"2022-01-06\",\r\n  \"currentJoiner\" : 0,\r\n  \"stateCode\" : \"STOPPED\",\r\n  \"stateName\" : \"중지\",\r\n  \"progress\" : 0.0\r\n}"
+                    "value" : "{\r\n  \"id\" : 3,\r\n  \"title\" : \"준비중인 대회 (1)\",\r\n  \"startDate\" : \"2022-01-09\",\r\n  \"endDate\" : \"2022-01-09\",\r\n  \"currentJoiner\" : 0,\r\n  \"stateCode\" : \"STOPPED\",\r\n  \"stateName\" : \"중지\",\r\n  \"progress\" : 0.0\r\n}"
                   }
                 }
               }
@@ -1106,7 +1106,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "contest-end-already" : {
@@ -1161,7 +1161,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "contest-join-already" : {
@@ -1202,7 +1202,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "contest-start-can-not" : {
@@ -1234,7 +1234,7 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/api-v1-member-1153901879"
+                  "$ref" : "#/components/schemas/api-v1-contest-contestId-stop-1153901879"
                 },
                 "examples" : {
                   "contest-stop-can-not" : {
@@ -1417,6 +1417,23 @@
           }
         }
       },
+      "api-v1-init781399800" : {
+        "type" : "object",
+        "properties" : {
+          "secretKey" : {
+            "type" : "string",
+            "description" : "암복호화 키"
+          },
+          "kakaoKey" : {
+            "type" : "string",
+            "description" : "카카오 API 키"
+          },
+          "adSenseKey" : {
+            "type" : "string",
+            "description" : "구글 애드센스 키"
+          }
+        }
+      },
       "api-v1-member-1099089930" : {
         "type" : "object",
         "properties" : {
@@ -1439,23 +1456,6 @@
           "id" : {
             "type" : "number",
             "description" : "회원 아이디"
-          }
-        }
-      },
-      "api-v1-init781399800" : {
-        "type" : "object",
-        "properties" : {
-          "secretKey" : {
-            "type" : "string",
-            "description" : "암복호화 키"
-          },
-          "kakaoKey" : {
-            "type" : "string",
-            "description" : "카카오 API 키"
-          },
-          "adSenseKey" : {
-            "type" : "string",
-            "description" : "구글 애드센스 키"
           }
         }
       },
@@ -1549,7 +1549,7 @@
           }
         }
       },
-      "api-v1-member-1153901879" : {
+      "api-v1-contest-contestId-stop-1153901879" : {
         "type" : "object",
         "properties" : {
           "code" : {

--- a/back-end/src/main/resources/static/index.html
+++ b/back-end/src/main/resources/static/index.html
@@ -558,9 +558,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 Content-Type: application/json;charset=UTF-8
 
 {
-  "secretKey" : "YCzS2qLU004s/pSkeRz3cJDOqWnyA8pytBuAtzCR39c=",
-  "kakaoKey" : "RECe6TFaGUMrxc0nmrDiV01jddcePB3XRU1nmdCEs5KJx35tTrVbqGel/skYWEt+Bg==",
-  "adSenseKey" : "yewFZjp5HwXGaZF77NXS4xx7bpVMPTGiIOD27vVIjs/MrqFB0dLcOHBrvuCgWg=="
+  "secretKey" : "mYhdmQWRbaHCkYV6vsQqjJePKAWiOT4sd0AF84Q03rs=",
+  "kakaoKey" : "yZj9w3iwryQHJyyifvI0MYIxlu7q6OpKB5kvD9b+RW4tYVadSkByoaWb5EAKffeUUA==",
+  "adSenseKey" : "5IGhzXKEr+6fMZTzcOyQHTd66Hp330AG00tqX+tHqBPr+D6ZQ5D27RtEWrgUGQ=="
 }</code></pre>
 </div>
 </div>
@@ -645,7 +645,7 @@ Content-Type: application/json
   "id" : 9999,
   "connectedAt" : 1.597679104E9,
   "profile" : {
-    "nickname" : "A1AZvsRo0fBMr2HlGmn9FsA/14EI6Eo7K91C3Lc6v9Ar",
+    "nickname" : "gIKZ7uKOtbrYKobRDGO0WLwO9BSqTxe5wjz1armpOYlu",
     "imageUrl" : "https://cataas.com/cat?width=200&amp;height=200",
     "thumbnailUrl" : "https://cataas.com/cat?width=160&amp;height=100",
     "needsAgreement" : true
@@ -733,7 +733,7 @@ Content-Type: application/json;charset=UTF-8
   "token" : "created jwt token value!",
   "member" : {
     "id" : 12,
-    "nickname" : "8bKdUXSpmPj2Z4q7+cbW6/JXiMJI8SeOeWrDWTMUvLsn",
+    "nickname" : "aCYl/ftXS2uFMgyWF8VE9qAIzHaT4vnYxY664zr1kxs8",
     "thumbnail" : "https://cataas.com/cat?width=160&amp;height=100",
     "manager" : false
   },
@@ -751,7 +751,7 @@ Content-Type: application/json;charset=UTF-8
   "token" : "created jwt token value!",
   "member" : {
     "id" : 12,
-    "nickname" : "IPIL0cjPLW89o+V4TxH7Yja4cVGG5ECOzf2PWYETbCRcUw==",
+    "nickname" : "gO94wzjkuoMZYX7iR9AmC4IDG46WwgLfqMhcFltcT73+Sw==",
     "handicap" : 22,
     "thumbnail" : "https://bar",
     "manager" : true
@@ -837,7 +837,7 @@ Content-Type: application/json
 Authorization: 2
 
 {
-  "nickname" : "0sUukr1+fX4CiWHUdQpnrn8BVDLSQMHqNw7QrAEWk8b2c3FgRjjWh5pPOrk=",
+  "nickname" : "LGpLo32Zr0I2oYphEkTt1xB3r94picbGhvPgTG2cVWpVtRp771h3w5GgEIs=",
   "handicap" : 30
 }</code></pre>
 </div>
@@ -905,7 +905,7 @@ Content-Type: application/json;charset=UTF-8
 
 {
   "id" : 2,
-  "nickname" : "yH8auWOxvpVhoXP75w5Rz4VQ+lfGm+1l7qc1ZGAHzE4ovvS5SvCHzMsv04A=",
+  "nickname" : "ZrW7zNtSUGvfEFGdRnS4PMo6wwD0lV85+Z6gpzbZPB61Qp0J58TTy5enALs=",
   "handicap" : 30,
   "thumbnail" : "https://img.foo.bar",
   "manager" : false
@@ -972,6 +972,9 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_대회_목록_조회"><a class="link" href="#_대회_목록_조회">대회 목록 조회</a></h4>
 <div class="paragraph">
 <p>대회 목록을 조회한다.</p>
+</div>
+<div class="paragraph">
+<p>일반 회원/관리자 권한에 따라 필터링된 목록이 조회된다.</p>
 </div>
 <table class="tableblock frame-all grid-all spread">
 <caption class="title">Table 6. request</caption>
@@ -1167,40 +1170,67 @@ Content-Type: application/json;charset=UTF-8
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
+Content-Length: 1350
 
 [ {
-  "id" : 1121,
-  "title" : "2020년 7월 동호회 리그전",
-  "description" : "총 상금 100만원!",
-  "startDate" : "2021-07-01",
-  "startTime" : "18:00:00",
-  "endDate" : "2020-07-31",
-  "endTime" : "22:00:00",
-  "maxJoiner" : 128,
+  "id" : 7,
+  "title" : "접수중 대회 - 인원 꽉참",
+  "startDate" : "2021-01-01",
+  "maxJoiner" : 2,
+  "currentJoiner" : 2,
+  "stateCode" : "ACCEPTING",
+  "stateName" : "접수중",
+  "progress" : 0.0
+}, {
+  "id" : 6,
+  "title" : "종료된 대회",
+  "startDate" : "2020-01-01",
   "currentJoiner" : 0,
   "stateCode" : "END",
   "stateName" : "종료",
+  "progress" : 0.0
+}, {
+  "id" : 2,
+  "title" : "2022 리그전",
+  "description" : "2021.05.01~",
+  "startDate" : "2021-01-01",
+  "startTime" : "00:00:00",
+  "endDate" : "2022-12-30",
+  "endTime" : "23:59:59",
+  "maxJoiner" : 128,
+  "currentJoiner" : 4,
+  "stateCode" : "ACCEPTING",
+  "stateName" : "접수중",
   "progress" : 0.0,
   "player" : {
-    "id" : 335,
-    "number" : 16,
-    "handicap" : 18,
-    "nickname" : "띠용",
-    "rank" : 5,
-    "score" : 600,
+    "id" : 9,
+    "handicap" : 28,
+    "nickname" : "잼미니",
+    "score" : 0,
     "variation" : 0
   }
 }, {
-  "id" : 1121,
-  "title" : "2022년 1분기 대회",
-  "startDate" : "2022-01-01",
-  "startTime" : "18:00:00",
-  "endDate" : "2022-03-31",
-  "maxJoiner" : 64,
-  "currentJoiner" : 0,
-  "stateCode" : "PREPARING",
-  "stateName" : "준비중",
-  "progress" : 0.0
+  "id" : 1,
+  "title" : "2021 리그전",
+  "description" : "2021.01.01~",
+  "startDate" : "2021-01-01",
+  "startTime" : "00:00:00",
+  "endDate" : "2021-12-30",
+  "endTime" : "23:59:59",
+  "maxJoiner" : 32,
+  "currentJoiner" : 5,
+  "stateCode" : "PROCEEDING",
+  "stateName" : "진행중",
+  "progress" : 0.0,
+  "player" : {
+    "id" : 3,
+    "number" : 3,
+    "handicap" : 26,
+    "nickname" : "잼미니",
+    "rank" : 5,
+    "score" : 10,
+    "variation" : 0
+  }
 } ]</code></pre>
 </div>
 </div>
@@ -1239,7 +1269,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/contest/1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNDc4OTUzLCJleHAiOjE2NDE0ODA3NTN9.IUs-pMm0qySZtuge9kBRJpLjTVJrjeQTlviCe3X2emM</code></pre>
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNjkzODAyLCJleHAiOjE2NDE2OTU2MDJ9.gzr-RrW-2tklgL8jjy756H4qv1bTDiI1X5MuUIlQUcE</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all spread">
@@ -2051,7 +2081,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/contest/2/join HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI1IiwiaWF0IjoxNjQxNDc4OTU0LCJleHAiOjE2NDE0ODA3NTR9.q1yOfsRhEVnCndozmVHj1WzUlQcluqQGQfqRn4P99vE
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI1IiwiaWF0IjoxNjQxNjkzODAyLCJleHAiOjE2NDE2OTU2MDJ9.oS7PCBCMmQmB9zShKQc4D4SOALddhqxsYqqF7iBYB6E
 Content-Length: 23
 
 {
@@ -2553,7 +2583,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/contest/3/open HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNDc4OTU1LCJleHAiOjE2NDE0ODA3NTV9.wxzPYXKI5yPxQCHJyxylD915-LTyukR32kqXb0EoLl4</code></pre>
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNjkzODA0LCJleHAiOjE2NDE2OTU2MDR9.9KxicxmasofwfVFQeFmFM7Z-oMeJ6SUoB1IU5v_hbXE</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all spread">
@@ -2670,8 +2700,8 @@ Content-Length: 221
 {
   "id" : 3,
   "title" : "준비중인 대회 (1)",
-  "startDate" : "2022-01-06",
-  "endDate" : "2022-01-06",
+  "startDate" : "2022-01-09",
+  "endDate" : "2022-01-09",
   "currentJoiner" : 0,
   "stateCode" : "ACCEPTING",
   "stateName" : "접수중",
@@ -2793,7 +2823,7 @@ Content-Length: 65
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/contest/2/start HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNDc4OTU3LCJleHAiOjE2NDE0ODA3NTd9.KZnN9o4Leenigu23ZBL_Acl7IcmBcg4iYAcVk0mgEY4</code></pre>
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNjkzODA2LCJleHAiOjE2NDE2OTU2MDZ9.NKtVwLHniMNjnNllNLV50ZI8UxmMht2B06dffCxjGI8</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all spread">
@@ -3034,7 +3064,7 @@ Content-Length: 65
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/contest/3/stop HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNDc4OTU4LCJleHAiOjE2NDE0ODA3NTh9.omawM366qh1xiXH1Q3Qnlj8FUuBqwKa_e5LG0SzHsow</code></pre>
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNjkzODA4LCJleHAiOjE2NDE2OTU2MDh9.fU1M2ypvyrgAI2ri1dKP5yWI-dlkLhssHjjZLsNo2Dk</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all spread">
@@ -3151,8 +3181,8 @@ Content-Length: 216
 {
   "id" : 3,
   "title" : "준비중인 대회 (1)",
-  "startDate" : "2022-01-06",
-  "endDate" : "2022-01-06",
+  "startDate" : "2022-01-09",
+  "endDate" : "2022-01-09",
   "currentJoiner" : 0,
   "stateCode" : "STOPPED",
   "stateName" : "중지",
@@ -3245,7 +3275,7 @@ Content-Length: 65
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/contest/5/end HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNDc4OTUyLCJleHAiOjE2NDE0ODA3NTJ9.OrB2iNUXsxxWc_E2QcvVfVi9FH0Jw2SZpro6REsInlE</code></pre>
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjQxNjkzODAwLCJleHAiOjE2NDE2OTU2MDB9.kdyd___6sEkts7wbwpHAvSLgpUNCXbI8Zqd9k5X73x8</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all spread">
@@ -4588,7 +4618,7 @@ Content-Type: application/json;charset=UTF-8
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2022-01-06 23:22:00 KST
+Last updated 2022-01-09 11:02:27 KST
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css">

--- a/back-end/src/test/java/org/antop/billiardslove/api/ContestInfoApiTest.java
+++ b/back-end/src/test/java/org/antop/billiardslove/api/ContestInfoApiTest.java
@@ -3,7 +3,6 @@ package org.antop.billiardslove.api;
 import org.antop.billiardslove.RestDocsUtils;
 import org.antop.billiardslove.WebMvcBase;
 import org.antop.billiardslove.dto.ContestDto;
-import org.antop.billiardslove.dto.PlayerDto;
 import org.antop.billiardslove.exception.ContestEndException;
 import org.antop.billiardslove.exception.ContestProceedingException;
 import org.antop.billiardslove.mapper.ContestMapperImpl;
@@ -24,10 +23,8 @@ import util.JsonUtils;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.Arrays;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.notNullValue;
@@ -35,7 +32,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -59,58 +55,6 @@ class ContestInfoApiTest extends WebMvcBase {
      */
     @MockBean
     private PlayerService playerService;
-
-    @DisplayName("대회 목록 조회")
-    @Test
-    void listApi() throws Exception {
-        // stub
-        when(contestService.getAllContests()).thenReturn(Arrays.asList(
-                ContestDto.builder()
-                        .id(1121L)
-                        .title("2020년 7월 동호회 리그전")
-                        .description("총 상금 100만원!")
-                        .startDate(LocalDate.of(2021, 7, 1))
-                        .startTime(LocalTime.of(18, 0, 0))
-                        .endDate(LocalDate.of(2020, 7, 31))
-                        .endTime(LocalTime.of(22, 0, 0))
-                        .stateCode(ContestState.END.name())
-                        .stateName(stateName(ContestState.END))
-                        .maxJoiner(128)
-                        .player(PlayerDto.builder()
-                                .id(335)
-                                .number(16)
-                                .nickname("띠용")
-                                .handicap(18)
-                                .rank(5)
-                                .score(600)
-                                .build())
-                        .build(),
-                ContestDto.builder()
-                        .id(1121L)
-                        .title("2022년 1분기 대회")
-                        .startDate(LocalDate.of(2022, 1, 1))
-                        .startTime(LocalTime.of(18, 0, 0))
-                        .endDate(LocalDate.of(2022, 3, 31))
-                        .stateCode(ContestState.PREPARING.name())
-                        .stateName(stateName(ContestState.PREPARING))
-                        .maxJoiner(64)
-                        .build()
-        ));
-        // action
-        mockMvc.perform(get("/api/v1/contests").header(HttpHeaders.AUTHORIZATION, userToken()))
-                // logging
-                .andDo(print())
-                .andDo(document("contest-list",
-                        requestHeaders(RestDocsUtils.Header.jwtToken()),
-                        responseFields(RestDocsUtils.FieldSnippet.contestsWithPlayer())
-                ))
-                // verify
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", hasSize(2)))
-                .andExpect(jsonPath("$[0].player").exists())
-                .andExpect(jsonPath("$[1].player").doesNotExist())
-        ;
-    }
 
     @DisplayName("대회 등록")
     @Test

--- a/back-end/src/test/java/org/antop/billiardslove/dao/ContestDaoTest.java
+++ b/back-end/src/test/java/org/antop/billiardslove/dao/ContestDaoTest.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.List;
 import java.util.Optional;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresent;
@@ -50,13 +49,4 @@ class ContestDaoTest extends SpringBootBase {
         assertThat(contest.getId(), notNullValue());
     }
 
-    @Test
-    void findAllWithPlayers() {
-        List<Contest> contests = dao.findAllOrdered();
-        // 시작일이 입력된 "준비중인 대회 (2)"가 "준비중인 대회 (1)"보다 위에 있어야 한다.
-        assertThat(contests.get(3).getId(), is(4L));
-        assertThat(contests.get(3).getTitle(), is("준비중인 대회 (2)"));
-        assertThat(contests.get(4).getId(), is(3L));
-        assertThat(contests.get(4).getTitle(), is("준비중인 대회 (1)"));
-    }
 }

--- a/back-end/src/test/java/org/antop/billiardslove/integration/ContestListTest.java
+++ b/back-end/src/test/java/org/antop/billiardslove/integration/ContestListTest.java
@@ -1,0 +1,75 @@
+package org.antop.billiardslove.integration;
+
+import org.antop.billiardslove.RestDocsUtils;
+import org.antop.billiardslove.SpringBootBase;
+import org.antop.billiardslove.config.security.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("대회 목록 조회 테스트")
+class ContestListTest extends SpringBootBase {
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @DisplayName("회원 대회 목록 조회")
+    @Test
+    void findForMember() throws Exception {
+        // given
+        String token = jwtTokenProvider.createToken(3L); // 회원
+        // when
+        ResultActions actions = request(token)
+                .andDo(document("contest-list",
+                        requestHeaders(RestDocsUtils.Header.jwtToken()),
+                        responseFields(RestDocsUtils.FieldSnippet.contestsWithPlayer())
+                ));
+        // then
+        actions.andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(4)))
+                .andExpect(jsonPath("$[0].player").doesNotExist())
+                .andExpect(jsonPath("$[1].player").doesNotExist())
+                .andExpect(jsonPath("$[2].player").exists())
+                .andExpect(jsonPath("$[3].player").exists())
+        ;
+    }
+
+    @DisplayName("관리자가 대회 목록 조회")
+    @Test
+    void findForManager() throws Exception {
+        // given
+        String token = jwtTokenProvider.createToken(1L); // 관리자
+        // when
+        ResultActions actions = request(token)
+                .andDo(document("contest-list",
+                        requestHeaders(RestDocsUtils.Header.jwtToken()),
+                        responseFields(RestDocsUtils.FieldSnippet.contestsWithPlayer())
+                ));
+        // then
+        actions.andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(7)))
+                .andExpect(jsonPath("$[5].player").exists())
+                .andExpect(jsonPath("$[6].player").exists())
+        ;
+    }
+
+    private ResultActions request(String token) throws Exception {
+        return mockMvc.perform(
+                        get("/api/v1/contests")
+                                .header(HttpHeaders.AUTHORIZATION, token)
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print());
+    }
+}

--- a/back-end/src/test/java/org/antop/billiardslove/integration/ContestListTest.java
+++ b/back-end/src/test/java/org/antop/billiardslove/integration/ContestListTest.java
@@ -51,11 +51,7 @@ class ContestListTest extends SpringBootBase {
         // given
         String token = jwtTokenProvider.createToken(1L); // 관리자
         // when
-        ResultActions actions = request(token)
-                .andDo(document("contest-list",
-                        requestHeaders(RestDocsUtils.Header.jwtToken()),
-                        responseFields(RestDocsUtils.FieldSnippet.contestsWithPlayer())
-                ));
+        ResultActions actions = request(token);
         // then
         actions.andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(7)))


### PR DESCRIPTION
주요 변경사항
1. 대회 목록 조회시 일반회원과 관리자에 따라 보여줄 대회 상태를 필터링
2. log4jdbc result table 출력 시 [가로 간격 맞춰주는 라이브러리](https://raw.githack.com/antop-dev/log4jdbc-log4j2-jdbc4.1)로 변경.

※ 회원용 목록에서 정렬 기준은 다시 정한다.